### PR TITLE
bug: wrap html and text bodies in an 'alternative' multipart

### DIFF
--- a/email-javamail-composer/src/main/java/io/micronaut/email/javamail/composer/DefaultMessageComposer.java
+++ b/email-javamail-composer/src/main/java/io/micronaut/email/javamail/composer/DefaultMessageComposer.java
@@ -107,13 +107,9 @@ public class DefaultMessageComposer implements MessageComposer {
         final MimeBodyPart mbp = new MimeBodyPart();
         MimeMultipart alternativeBody = new MimeMultipart(SUBTYPE_ALTERNATIVE);
         mbp.setContent(alternativeBody);
-        bodyParts(body).forEach(part -> {
-            try {
-                alternativeBody.addBodyPart(part);
-            } catch (MessagingException e) {
-
-            }
-        });
+        for (MimeBodyPart part : bodyParts(body)) {
+            alternativeBody.addBodyPart(part);
+        }
         return mbp;
     }
 

--- a/email-javamail-composer/src/main/java/io/micronaut/email/javamail/composer/DefaultMessageComposer.java
+++ b/email-javamail-composer/src/main/java/io/micronaut/email/javamail/composer/DefaultMessageComposer.java
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -60,13 +60,13 @@ public class DefaultMessageComposer implements MessageComposer {
     public static final String TYPE_TEXT_HTML_CHARSET_UTF_8 = "text/html; charset=UTF-8";
     private static final Logger LOG = LoggerFactory.getLogger(DefaultMessageComposer.class);
     private static final String SUBTYPE_ALTERNATIVE = "alternative";
-    private static final Map<BodyType, String> BODY_TYPES;
+    private static final EnumMap<BodyType, String> BODY_TYPES;
 
     static {
-        Map<BodyType, String> m = new HashMap<>(2);
+        EnumMap<BodyType, String> m = new EnumMap<>(BodyType.class);
         m.put(BodyType.TEXT, TYPE_TEXT_PLAIN_CHARSET_UTF_8);
         m.put(BodyType.HTML, TYPE_TEXT_HTML_CHARSET_UTF_8);
-        BODY_TYPES = Collections.unmodifiableMap(m);
+        BODY_TYPES = m;
     }
 
     @Override

--- a/email-javamail/build.gradle
+++ b/email-javamail/build.gradle
@@ -8,5 +8,7 @@ dependencies {
     implementation("io.micronaut:micronaut-validation")
     testImplementation(project(":test-suite-utils"))
     testImplementation("io.micronaut:micronaut-http")
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation("io.micronaut:micronaut-http-client")
     testCompileOnly("io.micronaut:micronaut-inject-groovy:$micronautVersion")
 }

--- a/email-javamail/src/main/java/io/micronaut/email/javamail/sender/JavaxEmailSender.java
+++ b/email-javamail/src/main/java/io/micronaut/email/javamail/sender/JavaxEmailSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,13 +38,14 @@ import java.util.function.Consumer;
 
 /**
  * Java Mail implementation of {@link io.micronaut.email.TransactionalEmailSender} and {@link io.micronaut.email.AsyncTransactionalEmailSender}.
+ *
  * @author Sergio del Amo
  * @since 1.0.0
  */
 @Named(JavaxEmailSender.NAME)
 @Secondary
 @Singleton
-@Requires(beans = { SessionProvider.class, MessageComposer.class })
+@Requires(beans = {SessionProvider.class, MessageComposer.class})
 public class JavaxEmailSender extends AbstractTransactionalEmailSender<Message, Void> {
     /**
      * {@link JavaxEmailSender} name.
@@ -57,7 +58,7 @@ public class JavaxEmailSender extends AbstractTransactionalEmailSender<Message, 
     private final JavaxEmailComposer javaxEmailComposer;
 
     /**
-     * @param executorService Executor service
+     * @param executorService    Executor service
      * @param javaxEmailComposer Message Composer
      */
     public JavaxEmailSender(@Named(TaskExecutors.IO) ExecutorService executorService,

--- a/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
+++ b/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
@@ -115,10 +115,6 @@ class JavaMailBodyAndAttachmentSpec extends Specification {
     @Introspected
     @ToString
     static class MessageResponse {
-
-        int total
-        int count
-        int start
         List<Item> items
     }
 

--- a/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
+++ b/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
@@ -1,6 +1,5 @@
 package io.micronaut.email.javamail
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import groovy.transform.ToString
 import io.micronaut.context.ApplicationContext

--- a/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
+++ b/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import groovy.transform.ToString
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.email.Attachment
 import io.micronaut.email.Email
@@ -106,6 +107,7 @@ class JavaMailBodyAndAttachmentSpec extends Specification {
                 .build()
     }
 
+    @Requires(property = "spec.name", value = "JavaxMailEmailSenderAttachmentSpec")
     @Client('${mailhog.uri}')
     static interface MailhogClient {
 

--- a/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
+++ b/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
@@ -113,7 +113,6 @@ class JavaMailBodyAndAttachmentSpec extends Specification {
     }
 
     @Introspected
-    @JsonIgnoreProperties(ignoreUnknown = true)
     @ToString
     static class MessageResponse {
 
@@ -125,7 +124,6 @@ class JavaMailBodyAndAttachmentSpec extends Specification {
 
     @Introspected
     @ToString
-    @JsonIgnoreProperties(ignoreUnknown = true)
     static class Item {
         @JsonProperty("Content")
         Content content
@@ -133,7 +131,6 @@ class JavaMailBodyAndAttachmentSpec extends Specification {
 
     @Introspected
     @ToString
-    @JsonIgnoreProperties(ignoreUnknown = true)
     static class Content {
         @JsonProperty("Headers")
         Map<String, String> headers

--- a/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
+++ b/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.email.Attachment
 import io.micronaut.email.Email
 import io.micronaut.email.EmailSender
 import io.micronaut.email.test.SpreadsheetUtils
+import io.micronaut.http.HttpHeaders
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
@@ -135,7 +136,7 @@ class JavaMailBodyAndAttachmentSpec extends Specification {
         String body
 
         MimeMultipart decoded() {
-            new MimeMultipart(new ByteArrayDataSource(body, headers.'Content-Type'))
+            new MimeMultipart(new ByteArrayDataSource(body, headers[HttpHeaders.CONTENT_TYPE]))
         }
     }
 }

--- a/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
+++ b/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
@@ -1,0 +1,148 @@
+package io.micronaut.email.javamail
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import groovy.transform.ToString
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.email.Attachment
+import io.micronaut.email.Email
+import io.micronaut.email.EmailSender
+import io.micronaut.email.test.SpreadsheetUtils
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+import io.netty.handler.codec.http.HttpHeaderNames
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import javax.mail.internet.MimeMultipart
+import javax.mail.util.ByteArrayDataSource
+
+class JavaMailBodyAndAttachmentSpec extends Specification {
+
+    @AutoCleanup
+    GenericContainer<?> mailHog = new GenericContainer<>(DockerImageName.parse("mailhog/mailhog"))
+            .withExposedPorts(1025, 8025)
+            .waitingFor(Wait.forHttp("/").forPort(8025))
+
+    @AutoCleanup
+    ApplicationContext applicationContext
+
+    private PollingConditions conditions = new PollingConditions()
+
+    def setup() {
+        mailHog.start()
+        applicationContext = ApplicationContext.run([
+                "spec.name"          : "JavaxMailEmailSenderAttachmentSpec",
+                "mailhog.uri"        : "http://${mailHog.getContainerIpAddress()}:${mailHog.getMappedPort(8025)}/",
+                'javamail.properties': ['mail.smtp.host': mailHog.getContainerIpAddress(),
+                                        "mail.smtp.port": mailHog.getMappedPort(1025)]])
+    }
+
+    def "Can send an email with alternate bodies and attachments"() {
+        given:
+        EmailSender emailSender = applicationContext.getBean(EmailSender)
+        MailhogClient client = applicationContext.getBean(MailhogClient)
+
+        and:
+        String from = "sender@here.com"
+        String to = "receiver@here.com"
+        String subject = "[Javax Mail] Attachment Test" + UUID.randomUUID().toString()
+        String html = "<h1>Hola Mundo</h1>"
+        String text = "Hello world"
+        String filename = "monthlyreports.xlsx"
+        String filename2 = "weeklyreports.xlsx"
+
+        when:
+        emailSender.send(
+                Email.builder()
+                        .from(from)
+                        .to(to)
+                        .subject(subject)
+                        .body(html, text)
+                        .attachment(createSpreadsheetAttachment(filename, MediaType.MICROSOFT_EXCEL_OPEN_XML))
+                        .attachment(createSpreadsheetAttachment(filename2, MediaType.APPLICATION_OCTET_STREAM))
+        )
+
+        then:
+        conditions.eventually {
+            with(client.messages().items[0]) {
+                content.headers.Subject == subject
+                content.headers.From == from
+                content.headers.To == to
+
+                with(content.decoded()) {
+                    // Alternative body messages come first
+                    with(getBodyPart(0)) {
+                        contentType.startsWith('multipart/alternative')
+                        content.parts.find { it.contentType.startsWith(MediaType.TEXT_PLAIN) }.content == text
+                        content.parts.find { it.contentType.startsWith(MediaType.TEXT_HTML) }.content == html
+                    }
+                    // Then the attachment(s)
+                    with(getBodyPart(1)) {
+                        contentType.startsWith(MediaType.MICROSOFT_EXCEL_OPEN_XML)
+                        getHeader(HttpHeaderNames.CONTENT_DISPOSITION.toString()).head() == "attachment; filename=$filename"
+                    }
+                    with(getBodyPart(2)) {
+                        contentType.startsWith(MediaType.APPLICATION_OCTET_STREAM)
+                        getHeader(HttpHeaderNames.CONTENT_DISPOSITION.toString()).head() == "attachment; filename=$filename2"
+                    }
+                }
+            }
+        }
+    }
+
+    private Attachment createSpreadsheetAttachment(String filename, String mediaType) {
+        Attachment.builder()
+                .filename(filename)
+                .contentType(mediaType)
+                .content(SpreadsheetUtils.spreadsheet())
+                .build()
+    }
+
+    @Client('${mailhog.uri}')
+    static interface MailhogClient {
+
+        @Get("/api/v2/messages")
+        MessageResponse messages()
+    }
+
+    @Introspected
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @ToString
+    static class MessageResponse {
+
+        int total
+        int count
+        int start
+        List<Item> items
+    }
+
+    @Introspected
+    @ToString
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class Item {
+        @JsonProperty("Content")
+        Content content
+    }
+
+    @Introspected
+    @ToString
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class Content {
+        @JsonProperty("Headers")
+        Map<String, String> headers
+
+        @JsonProperty("Body")
+        String body
+
+        MimeMultipart decoded() {
+            new MimeMultipart(new ByteArrayDataSource(body, headers.'Content-Type'))
+        }
+    }
+}


### PR DESCRIPTION
Used dockerized mailhog as a local test harness

Checked for binary compatibility, all ok so can be in a patch release

Fixes #44