### PR TITLE
Use the supplied contact name in JavaMail

### DIFF
--- a/email-javamail-composer/src/main/java/io/micronaut/email/javamail/composer/DefaultMessageComposer.java
+++ b/email-javamail-composer/src/main/java/io/micronaut/email/javamail/composer/DefaultMessageComposer.java
@@ -40,7 +40,6 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 import javax.mail.util.ByteArrayDataSource;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -118,7 +117,7 @@ public class DefaultMessageComposer implements MessageComposer {
     private Address[] contactAddresses(@NonNull Collection<Contact> contacts) throws AddressException {
         List<Address> addressList = new ArrayList<>();
         for (Contact contact : contacts) {
-            addressList.addAll(Arrays.asList(contactToAddress(contact)));
+            addressList.add(contactToAddress(contact));
         }
         Address[] array = new Address[addressList.size()];
         addressList.toArray(array);

--- a/email-javamail-composer/src/main/java/io/micronaut/email/javamail/composer/DefaultMessageComposer.java
+++ b/email-javamail-composer/src/main/java/io/micronaut/email/javamail/composer/DefaultMessageComposer.java
@@ -17,6 +17,7 @@ package io.micronaut.email.javamail.composer;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.email.Attachment;
 import io.micronaut.email.Body;
 import io.micronaut.email.BodyType;
@@ -75,7 +76,7 @@ public class DefaultMessageComposer implements MessageComposer {
                            @NonNull Session session) throws MessagingException {
         MimeMessage message = new MimeMessage(session);
         message.setSubject(email.getSubject(), "UTF-8");
-        message.setFrom(new InternetAddress(email.getFrom().getEmail()));
+        message.setFrom(contactToAddress(email.getFrom()));
         if (CollectionUtils.isNotEmpty(email.getTo())) {
             message.setRecipients(Message.RecipientType.TO, contactAddresses(email.getTo()));
         }
@@ -117,7 +118,7 @@ public class DefaultMessageComposer implements MessageComposer {
     private Address[] contactAddresses(@NonNull Collection<Contact> contacts) throws AddressException {
         List<Address> addressList = new ArrayList<>();
         for (Contact contact : contacts) {
-            addressList.addAll(Arrays.asList(InternetAddress.parse(contact.getEmail())));
+            addressList.addAll(Arrays.asList(contactToAddress(contact)));
         }
         Address[] array = new Address[addressList.size()];
         addressList.toArray(array);
@@ -168,5 +169,13 @@ public class DefaultMessageComposer implements MessageComposer {
         String reportName = attachment.getFilename();
         att.setFileName(reportName);
         return att;
+    }
+
+    private InternetAddress contactToAddress(Contact contact) throws AddressException {
+        if (StringUtils.isNotEmpty(contact.getName())) {
+            return InternetAddress.parse(contact.getName() + " <" + contact.getEmail() + ">")[0];
+        } else {
+            return InternetAddress.parse(contact.getEmail())[0];
+        }
     }
 }

--- a/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
+++ b/email-javamail/src/test/groovy/io/micronaut/email/javamail/JavaMailBodyAndAttachmentSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.email.Attachment
+import io.micronaut.email.Contact
 import io.micronaut.email.Email
 import io.micronaut.email.EmailSender
 import io.micronaut.email.test.SpreadsheetUtils
@@ -51,8 +52,8 @@ class JavaMailBodyAndAttachmentSpec extends Specification {
         MailhogClient client = applicationContext.getBean(MailhogClient)
 
         and:
-        String from = "sender@here.com"
-        String to = "receiver@here.com"
+        Contact from = new Contact("sender@here.com", "Zapp Brannigan")
+        Contact to = new Contact("receiver@here.com", "Kif")
         String subject = "[Javax Mail] Attachment Test" + UUID.randomUUID().toString()
         String html = "<h1>Hola Mundo</h1>"
         String text = "Hello world"
@@ -74,8 +75,8 @@ class JavaMailBodyAndAttachmentSpec extends Specification {
         conditions.eventually {
             with(client.messages().items[0]) {
                 content.headers.Subject == subject
-                content.headers.From == from
-                content.headers.To == to
+                content.headers.From == "$from.name <$from.email>"
+                content.headers.To == "$to.name <$to.email>"
 
                 with(content.decoded()) {
                     // Alternative body messages come first


### PR DESCRIPTION
As reported in Gitter, we were ignoring the supplied Contact name if one was provided, and just sending emails to (and from) the email address.

This check for a supplied name, and uses it to create the InternetAddress if one were specified