### PR TITLE
Migration to Gradle Version Catalog

### DIFF
--- a/email-amazon-ses/build.gradle
+++ b/email-amazon-ses/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor("io.micronaut:micronaut-validation")
+    annotationProcessor(libs.micronaut.validation)
     api(project(":email-javamail-composer"))
-    api("io.micronaut.aws:micronaut-aws-sdk-v2")
-    api("software.amazon.awssdk:ses")
-    implementation("io.micronaut.reactor:micronaut-reactor")
-    implementation("io.micronaut:micronaut-validation")
+    api(libs.micronaut.aws.sdk.v2)
+    api(libs.ses)
+    implementation(libs.micronaut.reactor)
+    implementation(libs.micronaut.validation)
     testImplementation(project(":test-suite-utils"))
-    testImplementation("io.micronaut:micronaut-http")
+    testImplementation(libs.micronaut.http)
 }

--- a/email-bom/build.gradle
+++ b/email-bom/build.gradle
@@ -1,11 +1,3 @@
 plugins {
     id "io.micronaut.build.internal.bom"
 }
-dependencies {
-    constraints {
-        api(libs.postmark)
-        api(libs.sendgrid.java)
-        api(libs.javax.mail)
-        api(libs.mailjet.client)
-    }
-}

--- a/email-bom/build.gradle
+++ b/email-bom/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 dependencies {
     constraints {
-        api("com.wildbit.java:postmark:$postmarkVersion")
-        api("com.sendgrid:sendgrid-java:$sendgridVersion")
-        api("com.sun.mail:javax.mail:$javaxmailVersion")
-        api("com.mailjet:mailjet-client:$mailjetVersion")
+        api(libs.postmark)
+        api(libs.sendgrid.java)
+        api(libs.javax.mail)
+        api(libs.mailjet.client)
     }
 }

--- a/email-javamail-composer/build.gradle
+++ b/email-javamail-composer/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     annotationProcessor(libs.micronaut.validation)
     api(project(":email"))
-    api(libs.javax.mail)
+    api(libs.managed.javax.mail)
     implementation(libs.micronaut.validation)
     testImplementation(project(":test-suite-utils"))
     testImplementation(libs.micronaut.http)

--- a/email-javamail-composer/build.gradle
+++ b/email-javamail-composer/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor("io.micronaut:micronaut-validation")
+    annotationProcessor(libs.micronaut.validation)
     api(project(":email"))
-    api("com.sun.mail:javax.mail:$javaxmailVersion")
-    implementation("io.micronaut:micronaut-validation")
+    api(libs.javax.mail)
+    implementation(libs.micronaut.validation)
     testImplementation(project(":test-suite-utils"))
-    testImplementation("io.micronaut:micronaut-http")
-    testCompileOnly("io.micronaut:micronaut-inject-groovy:$micronautVersion")
+    testImplementation(libs.micronaut.http)
+    testCompileOnly(libs.micronaut.inject.groovy)
 }

--- a/email-javamail/build.gradle
+++ b/email-javamail/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor("io.micronaut:micronaut-validation")
+    annotationProcessor(libs.micronaut.validation)
     api(project(":email-javamail-composer"))
-    implementation("io.micronaut:micronaut-validation")
+    implementation(libs.micronaut.validation)
     testImplementation(project(":test-suite-utils"))
-    testImplementation("io.micronaut:micronaut-http")
-    testImplementation("org.testcontainers:testcontainers")
-    testImplementation("io.micronaut:micronaut-http-client")
-    testCompileOnly("io.micronaut:micronaut-inject-groovy:$micronautVersion")
+    testImplementation(libs.micronaut.http)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.micronaut.http.client)
+    testCompileOnly(libs.micronaut.inject.groovy)
 }

--- a/email-mailjet/build.gradle
+++ b/email-mailjet/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     annotationProcessor(libs.micronaut.validation)
-    api(libs.mailjet.client)
+    api(libs.managed.mailjet.client)
     api(project(":email"))
     implementation(libs.micronaut.reactor)
     implementation(libs.micronaut.validation)

--- a/email-mailjet/build.gradle
+++ b/email-mailjet/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor("io.micronaut:micronaut-validation")
-    api("com.mailjet:mailjet-client:$mailjetVersion")
+    annotationProcessor(libs.micronaut.validation)
+    api(libs.mailjet.client)
     api(project(":email"))
-    implementation("io.micronaut.reactor:micronaut-reactor")
-    implementation("io.micronaut:micronaut-validation")
+    implementation(libs.micronaut.reactor)
+    implementation(libs.micronaut.validation)
     testImplementation(project(":test-suite-utils"))
-    testImplementation("io.micronaut:micronaut-http")
+    testImplementation(libs.micronaut.http)
 }

--- a/email-postmark/build.gradle
+++ b/email-postmark/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     annotationProcessor(libs.micronaut.validation)
-    api(libs.postmark)
+    api(libs.managed.postmark)
     api(project(":email"))
     implementation(libs.micronaut.validation)
     testImplementation(libs.micronaut.http)

--- a/email-postmark/build.gradle
+++ b/email-postmark/build.gradle
@@ -3,10 +3,10 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor("io.micronaut:micronaut-validation")
-    api("com.wildbit.java:postmark:$postmarkVersion")
+    annotationProcessor(libs.micronaut.validation)
+    api(libs.postmark)
     api(project(":email"))
-    implementation("io.micronaut:micronaut-validation")
-    testImplementation("io.micronaut:micronaut-http")
+    implementation(libs.micronaut.validation)
+    testImplementation(libs.micronaut.http)
     testImplementation project(":test-suite-utils")
 }

--- a/email-sendgrid/build.gradle
+++ b/email-sendgrid/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     annotationProcessor(libs.micronaut.validation)
-    api(libs.sendgrid.java)
+    api(libs.managed.sendgrid.java)
     api(project(":email"))
     implementation(libs.micronaut.reactor)
     implementation(libs.micronaut.validation)

--- a/email-sendgrid/build.gradle
+++ b/email-sendgrid/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor("io.micronaut:micronaut-validation")
-    api("com.sendgrid:sendgrid-java:$sendgridVersion")
+    annotationProcessor(libs.micronaut.validation)
+    api(libs.sendgrid.java)
     api(project(":email"))
-    implementation("io.micronaut.reactor:micronaut-reactor")
-    implementation("io.micronaut:micronaut-validation")
-    testImplementation("io.micronaut:micronaut-http")
+    implementation(libs.micronaut.reactor)
+    implementation(libs.micronaut.validation)
+    testImplementation(libs.micronaut.http)
     testImplementation(project(":test-suite-utils"))
 }

--- a/email-template/build.gradle
+++ b/email-template/build.gradle
@@ -4,8 +4,8 @@ plugins {
 group = "io.micronaut.email"
 
 dependencies {
-    annotationProcessor("io.micronaut:micronaut-validation")
-    implementation("io.micronaut:micronaut-validation")
-    api("io.micronaut.views:micronaut-views-core")
+    annotationProcessor(libs.micronaut.validation)
+    implementation(libs.micronaut.validation)
+    api(libs.micronaut.views.core)
     api(project(":email"))
 }

--- a/email/build.gradle
+++ b/email/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor("io.micronaut:micronaut-validation")
-    implementation("io.micronaut:micronaut-validation")
-    api("io.micronaut:micronaut-context")
-    implementation("io.micronaut.reactor:micronaut-reactor")
+    annotationProcessor(libs.micronaut.validation)
+    implementation(libs.micronaut.validation)
+    api(libs.micronaut.context)
+    implementation(libs.micronaut.reactor)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
-projectVersion=1.3.0-SNAPSHOT
+projectVersion=1.2.2-SNAPSHOT
 projectGroup=io.micronaut.email
 micronautDocsVersion=2.0.0
-micronautVersion=3.4.3
+micronautVersion=3.3.4
 micronautTestVersion=3.1.1
 groovyVersion=3.0.10
-spockVersion=2.0-groovy-3.0
+spockVersion=2.1-groovy-3.0
 
 title=Micronaut Email
 projectDesc=Integration with Transaction Email Providers
@@ -12,8 +12,7 @@ projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-email
 developers=Graeme Rocher
 
-# Micronaut core branch for BOM pull requests
-githubCoreBranch=3.5.x
+githubCoreBranch=3.4.x
 
 bomProperty=micronautEmailVersion
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,22 @@
 projectVersion=1.2.2-SNAPSHOT
 projectGroup=io.micronaut.email
 micronautDocsVersion=2.0.0
-micronautVersion=3.3.4
-micronautTestVersion=3.0.5
+micronautVersion=3.4.3
+micronautTestVersion=3.1.1
 groovyVersion=3.0.10
 spockVersion=2.0-groovy-3.0
+
 title=Micronaut Email
 projectDesc=Integration with Transaction Email Providers
 projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-email
 developers=Graeme Rocher
-sendgridVersion=4.9.1
-postmarkVersion=1.8.0
-mailjetVersion=5.2.0
-javaxmailVersion=1.6.2
-poiOoxmlVersion=5.2.0
-githubCoreBranch=3.4.x
+
+# Micronaut core branch for BOM pull requests
+githubCoreBranch=3.5.x
+
 bomProperty=micronautEmailVersion
+
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx1g
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.2.2-SNAPSHOT
+projectVersion=1.3.0-SNAPSHOT
 projectGroup=io.micronaut.email
 micronautDocsVersion=2.0.0
 micronautVersion=3.4.3

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,25 +1,25 @@
 [versions]
-javaxmail = "1.6.2"
-mailjet = "5.2.0"
+managed-postmark = "1.8.0"
+managed-sendgrid = "4.9.1"
+managed-javax-mail = "1.6.2"
+managed-mailjet = "5.2.0"
+
 poi-ooxml = "5.2.0"
-postmark = "1.8.0"
-sendgrid = "4.9.1"
 kotlin = "1.6.20"
 
-# Micronaut
-micronaut = "3.4.3"
-
-
 [libraries]
-# BOMs
-boms-micronaut = { module = "io.micronaut:micronaut-bom", version.ref = "micronaut" }
+# Managed dependencies
+managed-postmark = { module = "com.wildbit.java:postmark", version.ref = "managed-postmark" }
+managed-sendgrid-java = { module = "com.sendgrid:sendgrid-java", version.ref = "managed-sendgrid" }
+managed-javax-mail = { module = "com.sun.mail:javax.mail", version.ref = "managed-javax-mail" }
+managed-mailjet-client = { module = "com.mailjet:mailjet-client", version.ref = "managed-mailjet" }
 
 # Micronaut
 micronaut-aws-sdk-v2 = { module = "io.micronaut.aws:micronaut-aws-sdk-v2" }
 micronaut-context = { module = "io.micronaut:micronaut-context" }
 micronaut-http = { module = "io.micronaut:micronaut-http" }
 micronaut-http-client = { module = "io.micronaut:micronaut-http-client" }
-micronaut-inject-groovy = { module = "io.micronaut:micronaut-inject-groovy", version.ref = "micronaut" }
+micronaut-inject-groovy = { module = "io.micronaut:micronaut-inject-groovy" }
 micronaut-inject-java = { module = "io.micronaut:micronaut-inject-java" }
 micronaut-reactor = { module = "io.micronaut.reactor:micronaut-reactor" }
 micronaut-test-junit5 = { module = "io.micronaut.test:micronaut-test-junit5" }
@@ -28,13 +28,9 @@ micronaut-validation = { module = "io.micronaut:micronaut-validation" }
 micronaut-views-core = { module = "io.micronaut.views:micronaut-views-core" }
 micronaut-views-velocity = { module = "io.micronaut.views:micronaut-views-velocity" }
 
-javax-mail = { module = "com.sun.mail:javax.mail", version.ref = "javaxmail" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
-mailjet-client = { module = "com.mailjet:mailjet-client", version.ref = "mailjet" }
 poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi-ooxml" }
-postmark = { module = "com.wildbit.java:postmark", version.ref = "postmark" }
-sendgrid-java = { module = "com.sendgrid:sendgrid-java", version.ref = "sendgrid" }
 ses = { module = "software.amazon.awssdk:ses" }
 testcontainers = { module = "org.testcontainers:testcontainers" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,40 @@
+[versions]
+javaxmail = "1.6.2"
+mailjet = "5.2.0"
+poi-ooxml = "5.2.0"
+postmark = "1.8.0"
+sendgrid = "4.9.1"
+kotlin = "1.6.20"
+
+# Micronaut
+micronaut = "3.4.3"
+
+
+[libraries]
+# BOMs
+boms-micronaut = { module = "io.micronaut:micronaut-bom", version.ref = "micronaut" }
+
+# Micronaut
+micronaut-aws-sdk-v2 = { module = "io.micronaut.aws:micronaut-aws-sdk-v2" }
+micronaut-context = { module = "io.micronaut:micronaut-context" }
+micronaut-http = { module = "io.micronaut:micronaut-http" }
+micronaut-http-client = { module = "io.micronaut:micronaut-http-client" }
+micronaut-inject-groovy = { module = "io.micronaut:micronaut-inject-groovy", version.ref = "micronaut" }
+micronaut-inject-java = { module = "io.micronaut:micronaut-inject-java" }
+micronaut-reactor = { module = "io.micronaut.reactor:micronaut-reactor" }
+micronaut-test-junit5 = { module = "io.micronaut.test:micronaut-test-junit5" }
+micronaut-test-spock = { module = "io.micronaut.test:micronaut-test-spock" }
+micronaut-validation = { module = "io.micronaut:micronaut-validation" }
+micronaut-views-core = { module = "io.micronaut.views:micronaut-views-core" }
+micronaut-views-velocity = { module = "io.micronaut.views:micronaut-views-velocity" }
+
+javax-mail = { module = "com.sun.mail:javax.mail", version.ref = "javaxmail" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
+mailjet-client = { module = "com.mailjet:mailjet-client", version.ref = "mailjet" }
+poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi-ooxml" }
+postmark = { module = "com.wildbit.java:postmark", version.ref = "postmark" }
+sendgrid-java = { module = "com.sendgrid:sendgrid-java", version.ref = "sendgrid" }
+ses = { module = "software.amazon.awssdk:ses" }
+testcontainers = { module = "org.testcontainers:testcontainers" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.3.2'
+    id("io.micronaut.build.shared.settings") version "5.3.4"
 }
 
 rootProject.name = 'email-parent'

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -5,18 +5,18 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    testCompileOnly("io.micronaut:micronaut-inject-groovy:$micronautVersion")
+    testCompileOnly(libs.micronaut.inject.groovy)
 
-    testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
-    testImplementation("io.micronaut:micronaut-validation")
+    testImplementation(platform(libs.boms.micronaut))
+    testImplementation(libs.micronaut.validation)
     testImplementation("org.spockframework:spock-core:${spockVersion}") {
         exclude module: 'groovy-all'
     }
     testImplementation(project(":test-suite-utils"))
     testImplementation(project(":email"))
     testImplementation(project(":email-template"))
-    testImplementation "io.micronaut.test:micronaut-test-spock"
-    testImplementation("io.micronaut.views:micronaut-views-velocity")
+    testImplementation(libs.micronaut.test.spock)
+    testImplementation(libs.micronaut.views.velocity)
 }
 
 tasks.named('test') {

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -7,7 +7,7 @@ repositories {
 dependencies {
     testCompileOnly(libs.micronaut.inject.groovy)
 
-    testImplementation(platform(libs.boms.micronaut))
+    testImplementation(platform("io.micronaut:micronaut-bom:${micronautVersion}"))
     testImplementation(libs.micronaut.validation)
     testImplementation("org.spockframework:spock-core:${spockVersion}") {
         exclude module: 'groovy-all'

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation(platform(libs.boms.micronaut))
+    testImplementation(platform("io.micronaut:micronaut-bom:${micronautVersion}"))
     testImplementation(libs.micronaut.validation)
 
     testImplementation(libs.junit.jupiter.api)
@@ -16,7 +16,8 @@ dependencies {
     testRuntimeOnly(libs.junit.jupiter.engine)
 
     testImplementation(libs.kotlin.stdlib.jdk8)
-    kaptTest(platform(libs.boms.micronaut))
+
+    kaptTest(platform("io.micronaut:micronaut-bom:${micronautVersion}"))
     kaptTest(libs.micronaut.inject.java)
 
     testImplementation project(":email")

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -8,20 +8,21 @@ repositories {
 }
 
 dependencies {
-    testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
-    testImplementation("io.micronaut:micronaut-validation")
+    testImplementation(platform(libs.boms.micronaut))
+    testImplementation(libs.micronaut.validation)
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testImplementation "io.micronaut.test:micronaut-test-junit5"
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.micronaut.test.junit5)
+    testRuntimeOnly(libs.junit.jupiter.engine)
 
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.20"
-    kaptTest "io.micronaut:micronaut-inject-java:$micronautVersion"
+    testImplementation(libs.kotlin.stdlib.jdk8)
+    kaptTest(platform(libs.boms.micronaut))
+    kaptTest(libs.micronaut.inject.java)
 
     testImplementation project(":email")
     testImplementation project(":email-template")
     testImplementation(project(":test-suite-utils"))
-    testImplementation("io.micronaut.views:micronaut-views-velocity")
+    testImplementation(libs.micronaut.views.velocity)
 }
 
 tasks.named('test') {

--- a/test-suite-utils/build.gradle
+++ b/test-suite-utils/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    api(libs.javax.mail)
+    api(libs.managed.javax.mail)
     api(libs.poi.ooxml)
 }
 

--- a/test-suite-utils/build.gradle
+++ b/test-suite-utils/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    api("com.sun.mail:javax.mail:$javaxmailVersion")
-    api("org.apache.poi:poi-ooxml:$poiOoxmlVersion")
+    api(libs.javax.mail)
+    api(libs.poi.ooxml)
 }
 
 java {

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -5,11 +5,11 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    testAnnotationProcessor(platform(libs.boms.micronaut))
+    testAnnotationProcessor(platform("io.micronaut:micronaut-bom:${micronautVersion}"))
     testAnnotationProcessor(libs.micronaut.inject.java)
     testAnnotationProcessor(libs.micronaut.validation)
 
-    testImplementation(platform(libs.boms.micronaut))
+    testImplementation(platform("io.micronaut:micronaut-bom:${micronautVersion}"))
     testImplementation(libs.micronaut.validation)
 
     testImplementation(libs.junit.jupiter.api)

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -5,22 +5,22 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    testAnnotationProcessor(platform("io.micronaut:micronaut-bom:$micronautVersion"))
-    testAnnotationProcessor "io.micronaut:micronaut-inject-java"
-    testAnnotationProcessor("io.micronaut:micronaut-validation")
+    testAnnotationProcessor(platform(libs.boms.micronaut))
+    testAnnotationProcessor(libs.micronaut.inject.java)
+    testAnnotationProcessor(libs.micronaut.validation)
 
-    testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
-    testImplementation("io.micronaut:micronaut-validation")
+    testImplementation(platform(libs.boms.micronaut))
+    testImplementation(libs.micronaut.validation)
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testImplementation "io.micronaut.test:micronaut-test-junit5"
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.micronaut.test.junit5)
+    testRuntimeOnly(libs.junit.jupiter.engine)
 
     testImplementation(project(":test-suite-utils"))
     testImplementation(project(":email"))
     testImplementation(project(":email-template"))
 
-    testImplementation("io.micronaut.views:micronaut-views-velocity")
+    testImplementation(libs.micronaut.views.velocity)
 }
 
 tasks.named('test') {


### PR DESCRIPTION
Supersedes #73 

Basically the same, but uses managed catalog versions instead of api constraints.

Doesn't need to target 3.5.x as it's not the addition of the BOM (it was already there)

