### PR TITLE
Use the supplied sender name in SesEmailComposer

### DIFF
--- a/email-amazon-ses/src/main/java/io/micronaut/email/ses/SesEmailComposer.java
+++ b/email-amazon-ses/src/main/java/io/micronaut/email/ses/SesEmailComposer.java
@@ -96,7 +96,9 @@ public class SesEmailComposer implements EmailComposer<SesRequest> {
     private SendEmailRequest sendEmailRequest(@NonNull Email email) {
         SendEmailRequest.Builder requestBuilder = SendEmailRequest.builder()
                 .destination(destinationBuilder(email).build())
-                .source(sourceFormatter(email))
+                .source(StringUtils.isNotEmpty(email.getFrom().getName()) ?
+                    email.getFrom().getNameAddress() :
+                    email.getFrom().getEmail())
                 .message(message(email));
         if (email.getReplyTo() != null) {
             requestBuilder = requestBuilder.replyToAddresses(email.getReplyTo().getEmail());
@@ -136,22 +138,5 @@ public class SesEmailComposer implements EmailComposer<SesRequest> {
             body.get(BodyType.HTML).map(it -> Content.builder().data(it).build()).ifPresent(bodyBuilder::html);
         }
         return bodyBuilder;
-    }
-
-    /**
-     * Formats the FROM address of an email to display both the contact's sender name (also known as the <i>friendly name</i>)
-     * and the address itself.
-     *
-     * @param email Email
-     * @return the formatted FROM address with the preceding sender name if present, or just the address if not.
-     */
-    @NonNull
-    protected String sourceFormatter(@NonNull Email email) {
-        io.micronaut.email.Contact from = email.getFrom();
-        if (StringUtils.isNotEmpty(from.getName())) {
-            return String.format("%s <%s>", from.getName(), from.getEmail());
-        } else {
-            return from.getEmail();
-        }
     }
 }

--- a/email-amazon-ses/src/main/java/io/micronaut/email/ses/SesEmailComposer.java
+++ b/email-amazon-ses/src/main/java/io/micronaut/email/ses/SesEmailComposer.java
@@ -17,6 +17,7 @@ package io.micronaut.email.ses;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.email.BodyType;
 import io.micronaut.email.Contact;
 import io.micronaut.email.Email;
@@ -95,7 +96,7 @@ public class SesEmailComposer implements EmailComposer<SesRequest> {
     private SendEmailRequest sendEmailRequest(@NonNull Email email) {
         SendEmailRequest.Builder requestBuilder = SendEmailRequest.builder()
                 .destination(destinationBuilder(email).build())
-                .source(email.getFrom().getEmail())
+                .source(sourceFormatter(email))
                 .message(message(email));
         if (email.getReplyTo() != null) {
             requestBuilder = requestBuilder.replyToAddresses(email.getReplyTo().getEmail());
@@ -135,5 +136,22 @@ public class SesEmailComposer implements EmailComposer<SesRequest> {
             body.get(BodyType.HTML).map(it -> Content.builder().data(it).build()).ifPresent(bodyBuilder::html);
         }
         return bodyBuilder;
+    }
+
+    /**
+     * Formats the FROM address of an email to display both the contact's sender name (also known as the <i>friendly name</i>)
+     * and the address itself.
+     *
+     * @param email Email
+     * @return the formatted FROM address with the preceding sender name if present, or just the address if not.
+     */
+    @NonNull
+    protected String sourceFormatter(@NonNull Email email) {
+        io.micronaut.email.Contact from = email.getFrom();
+        if (StringUtils.isNotEmpty(from.getName())) {
+            return String.format("%s <%s>", from.getName(), from.getEmail());
+        } else {
+            return from.getEmail();
+        }
     }
 }

--- a/email-amazon-ses/src/test/groovy/io/micronaut/email/ses/SesEmailComposerSpec.groovy
+++ b/email-amazon-ses/src/test/groovy/io/micronaut/email/ses/SesEmailComposerSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import software.amazon.awssdk.services.ses.model.SendEmailRequest
 import spock.lang.Specification
+import spock.lang.Unroll
 
 @MicronautTest(startApplication = false)
 class SesEmailComposerSpec extends Specification {
@@ -111,27 +112,32 @@ class SesEmailComposerSpec extends Specification {
         !request.destination().ccAddresses()
     }
 
-    void "from field should allow including the sender name"() {
+    @Unroll
+    void "from field should allow including the sender name"(String name, String email, String expected) {
         given:
-        Contact from = new Contact("sender@example.com", "John Doe")
-        String formattedFrom = "${from.getName()} <${from.getEmail()}>"
+        Contact from = new Contact(email, name)
         String to = "receiver@example.com"
         String subject = "Apple Music"
 
-        Email email = Email.builder()
+        when:
+        SendEmailRequest request = sesEmailComposer.compose(Email.builder()
                 .from(from)
                 .to(to)
                 .subject(subject)
                 .body("Lore ipsum body")
-                .build()
-        when:
-        SendEmailRequest request = sesEmailComposer.compose(email) as SendEmailRequest
+                .build()) as SendEmailRequest
 
         then:
-        formattedFrom == request.source()
+        expected == request.source()
         [to] == request.destination().toAddresses().toList()
         subject == request.message().subject().data()
         !request.destination().ccAddresses()
         !request.destination().bccAddresses()
+
+        where:
+        name       | email                | expected
+        "John Doe" | "sender@example.com" | "John Doe <sender@example.com>"
+        ""         | "sender@example.com" | "sender@example.com"
+        null       | "sender@example.com" | "sender@example.com"
     }
 }

--- a/email-amazon-ses/src/test/groovy/io/micronaut/email/ses/SesEmailComposerSpec.groovy
+++ b/email-amazon-ses/src/test/groovy/io/micronaut/email/ses/SesEmailComposerSpec.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.email.ses
 
-
+import io.micronaut.email.Contact
 import io.micronaut.email.Email
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -109,5 +109,29 @@ class SesEmailComposerSpec extends Specification {
         [replyTo] == request.replyToAddresses()
         subject == request.message().subject().data()
         !request.destination().ccAddresses()
+    }
+
+    void "from field should allow including the sender name"() {
+        given:
+        Contact from = new Contact("sender@example.com", "John Doe")
+        String formattedFrom = "${from.getName()} <${from.getEmail()}>"
+        String to = "receiver@example.com"
+        String subject = "Apple Music"
+
+        Email email = Email.builder()
+                .from(from)
+                .to(to)
+                .subject(subject)
+                .body("Lore ipsum body")
+                .build()
+        when:
+        SendEmailRequest request = sesEmailComposer.compose(email) as SendEmailRequest
+
+        then:
+        formattedFrom == request.source()
+        [to] == request.destination().toAddresses().toList()
+        subject == request.message().subject().data()
+        !request.destination().ccAddresses()
+        !request.destination().bccAddresses()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-email
 developers=Sergio del Amo
 
-githubCoreBranch=3.6.x
+githubCoreBranch=3.8.x
 
 bomProperty=micronautEmailVersion
 


### PR DESCRIPTION
Possible fix for https://github.com/micronaut-projects/micronaut-email/issues/117
Replaces https://github.com/micronaut-projects/micronaut-email/pull/127