### PR TITLE
Allow more than one Reply-To contact in order to be compliant with the Mail RFC

### DIFF
--- a/email-amazon-ses/src/main/java/io/micronaut/email/ses/SesEmailComposer.java
+++ b/email-amazon-ses/src/main/java/io/micronaut/email/ses/SesEmailComposer.java
@@ -43,8 +43,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Properties;
 
-import static java.util.stream.Collectors.toList;
-
 /**
  * @author Sergio del Amo
  * @since 1.0.0
@@ -100,7 +98,7 @@ public class SesEmailComposer implements EmailComposer<SesRequest> {
                 .message(message(email));
         if (CollectionUtils.isNotEmpty(email.getReplyToCollection())) {
             requestBuilder = requestBuilder.replyToAddresses(
-                email.getReplyToCollection().stream().map(Contact::getEmail).collect(toList()));
+                email.getReplyToCollection().stream().map(Contact::getEmail).toList());
         }
         return requestBuilder.build();
     }

--- a/email-amazon-ses/src/main/java/io/micronaut/email/ses/SesEmailComposer.java
+++ b/email-amazon-ses/src/main/java/io/micronaut/email/ses/SesEmailComposer.java
@@ -43,6 +43,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Properties;
 
+import static java.util.stream.Collectors.toList;
+
 /**
  * @author Sergio del Amo
  * @since 1.0.0
@@ -96,8 +98,9 @@ public class SesEmailComposer implements EmailComposer<SesRequest> {
                 .destination(destinationBuilder(email).build())
                 .source(email.getFrom().getEmail())
                 .message(message(email));
-        if (email.getReplyTo() != null) {
-            requestBuilder = requestBuilder.replyToAddresses(email.getReplyTo().getEmail());
+        if (CollectionUtils.isNotEmpty(email.getReplyToCollection())) {
+            requestBuilder = requestBuilder.replyToAddresses(
+                email.getReplyToCollection().stream().map(Contact::getEmail).collect(toList()));
         }
         return requestBuilder.build();
     }

--- a/email-amazon-ses/src/test/groovy/io/micronaut/email/ses/SesEmailComposerSpec.groovy
+++ b/email-amazon-ses/src/test/groovy/io/micronaut/email/ses/SesEmailComposerSpec.groovy
@@ -15,9 +15,9 @@ class SesEmailComposerSpec extends Specification {
 
     void "from, to and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def subject = "Apple Music"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String subject = "Apple Music"
 
         Email email = Email.builder()
                 .from(from)
@@ -26,7 +26,7 @@ class SesEmailComposerSpec extends Specification {
                 .body("Lore ipsum body")
                 .build()
         when:
-        def request = sesEmailComposer.compose(email) as SendEmailRequest
+        SendEmailRequest request = sesEmailComposer.compose(email)
 
         then:
         from == request.source()
@@ -38,10 +38,10 @@ class SesEmailComposerSpec extends Specification {
 
     void "from, to, cc and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def cc = "receiver.cc@example.com"
-        def subject = "Apple Music"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String cc = "receiver.cc@example.com"
+        String subject = "Apple Music"
 
         Email email = Email.builder()
                 .from(from)
@@ -51,7 +51,7 @@ class SesEmailComposerSpec extends Specification {
                 .body("Lore ipsum body")
                 .build()
         when:
-        def request = sesEmailComposer.compose(email) as SendEmailRequest
+        SendEmailRequest request = sesEmailComposer.compose(email)
 
         then:
         from == request.source()
@@ -63,10 +63,10 @@ class SesEmailComposerSpec extends Specification {
 
     void "from, to, bcc and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def bcc = "receiver.bcc@example.com"
-        def subject = "Apple Music"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String bcc = "receiver.bcc@example.com"
+        String subject = "Apple Music"
 
         Email email = Email.builder()
                 .from(from)
@@ -76,7 +76,7 @@ class SesEmailComposerSpec extends Specification {
                 .body("Lore ipsum body")
                 .build()
         when:
-        def request = sesEmailComposer.compose(email) as SendEmailRequest
+        SendEmailRequest request = sesEmailComposer.compose(email)
 
         then:
         from == request.source()
@@ -88,10 +88,10 @@ class SesEmailComposerSpec extends Specification {
 
     void "from, to, reply to and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def replyTo = "sender.reply.to@example.com"
-        def subject = "Apple Music"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String replyTo = "sender.reply.to@example.com"
+        String subject = "Apple Music"
 
         Email email = Email.builder()
                 .from(from)
@@ -101,7 +101,7 @@ class SesEmailComposerSpec extends Specification {
                 .body("Lore ipsum body")
                 .build()
         when:
-        def request = sesEmailComposer.compose(email) as SendEmailRequest
+        SendEmailRequest request = sesEmailComposer.compose(email)
 
         then:
         from == request.source()
@@ -128,7 +128,7 @@ class SesEmailComposerSpec extends Specification {
                 .body("Lore ipsum body")
                 .build()
         when:
-        def request = sesEmailComposer.compose(email) as SendEmailRequest
+        SendEmailRequest request = sesEmailComposer.compose(email)
 
         then:
         from == request.source()

--- a/email-amazon-ses/src/test/groovy/io/micronaut/email/ses/SesEmailComposerSpec.groovy
+++ b/email-amazon-ses/src/test/groovy/io/micronaut/email/ses/SesEmailComposerSpec.groovy
@@ -110,4 +110,31 @@ class SesEmailComposerSpec extends Specification {
         subject == request.message().subject().data()
         !request.destination().ccAddresses()
     }
+
+    void "from, to, multiple reply to and subject are put to the mime message"() {
+        given:
+        def from = "sender@example.com"
+        def to = "receiver@example.com"
+        def replyTo1 = "sender.reply.to.one@example.com"
+        def replyTo2 = "sender.reply.to.two@example.com"
+        def subject = "Apple Music"
+
+        Email email = Email.builder()
+                .from(from)
+                .to(to)
+                .replyTo(replyTo1)
+                .replyTo(replyTo2)
+                .subject(subject)
+                .body("Lore ipsum body")
+                .build()
+        when:
+        def request = sesEmailComposer.compose(email) as SendEmailRequest
+
+        then:
+        from == request.source()
+        [to] == request.destination().toAddresses().toList()
+        [replyTo1, replyTo2] == request.replyToAddresses()
+        subject == request.message().subject().data()
+        !request.destination().ccAddresses()
+    }
 }

--- a/email-amazon-ses/src/test/groovy/io/micronaut/email/ses/SesEmailComposerSpec.groovy
+++ b/email-amazon-ses/src/test/groovy/io/micronaut/email/ses/SesEmailComposerSpec.groovy
@@ -113,11 +113,11 @@ class SesEmailComposerSpec extends Specification {
 
     void "from, to, multiple reply to and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def replyTo1 = "sender.reply.to.one@example.com"
-        def replyTo2 = "sender.reply.to.two@example.com"
-        def subject = "Apple Music"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String replyTo1 = "sender.reply.to.one@example.com"
+        String replyTo2 = "sender.reply.to.two@example.com"
+        String subject = "Apple Music"
 
         Email email = Email.builder()
                 .from(from)

--- a/email-javamail-composer/src/main/java/io/micronaut/email/javamail/composer/DefaultMessageComposer.java
+++ b/email-javamail-composer/src/main/java/io/micronaut/email/javamail/composer/DefaultMessageComposer.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 /**
  * {@link io.micronaut.context.annotation.DefaultImplementation} of {@link MessageComposer}.
@@ -84,8 +83,8 @@ public class DefaultMessageComposer implements MessageComposer {
         if (CollectionUtils.isNotEmpty(email.getBcc())) {
             message.setRecipients(Message.RecipientType.BCC, contactAddresses(email.getBcc()));
         }
-        if (null != email.getReplyTo()) {
-            message.setReplyTo(contactAddresses(Stream.of(email.getReplyTo()).toList()));
+        if (CollectionUtils.isNotEmpty(email.getReplyToCollection())) {
+            message.setReplyTo(contactAddresses(email.getReplyToCollection()));
         }
 
         MimeMultipart multipart = new MimeMultipart();

--- a/email-javamail-composer/src/test/groovy/io/micronaut/email/javamail/composer/DefaultMessageComposerSpec.groovy
+++ b/email-javamail-composer/src/test/groovy/io/micronaut/email/javamail/composer/DefaultMessageComposerSpec.groovy
@@ -14,9 +14,9 @@ class DefaultMessageComposerSpec extends Specification {
 
     void "from, to and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def subject = "Apple Music"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String subject = "Apple Music"
 
         Email email = Email.builder()
                 .from(from)
@@ -25,7 +25,7 @@ class DefaultMessageComposerSpec extends Specification {
                 .body("Lore ipsum body")
                 .build()
         when:
-        def message = defaultMessageComposer.compose(email, null)
+        Message message = defaultMessageComposer.compose(email, null)
 
         then:
         [from] == message.from.toList().collect {it.address }
@@ -37,10 +37,10 @@ class DefaultMessageComposerSpec extends Specification {
 
     void "from, to, cc and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def cc = "receiver.cc@example.com"
-        def subject = "Apple Music"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String cc = "receiver.cc@example.com"
+        String subject = "Apple Music"
 
         Email email = Email.builder()
                 .from(from)
@@ -50,7 +50,7 @@ class DefaultMessageComposerSpec extends Specification {
                 .body("Lore ipsum body")
                 .build()
         when:
-        def message = defaultMessageComposer.compose(email, null)
+        Message message = defaultMessageComposer.compose(email, null)
 
         then:
         [from] == message.from.toList().collect {it.address }
@@ -62,10 +62,10 @@ class DefaultMessageComposerSpec extends Specification {
 
     void "from, to, bcc and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def bcc = "receiver.bcc@example.com"
-        def subject = "Apple Music"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String bcc = "receiver.bcc@example.com"
+        String subject = "Apple Music"
 
         Email email = Email.builder()
                 .from(from)
@@ -75,7 +75,7 @@ class DefaultMessageComposerSpec extends Specification {
                 .body("Lore ipsum body")
                 .build()
         when:
-        def message = defaultMessageComposer.compose(email, null)
+        Message message = defaultMessageComposer.compose(email, null)
 
         then:
         [from] == message.from.toList().collect {it.address }
@@ -87,10 +87,10 @@ class DefaultMessageComposerSpec extends Specification {
 
     void "from, to, reply to and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def replyTo = "sender.reply.to@example.com"
-        def subject = "Apple Music"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String replyTo = "sender.reply.to@example.com"
+        String subject = "Apple Music"
 
         Email email = Email.builder()
                 .from(from)
@@ -100,7 +100,7 @@ class DefaultMessageComposerSpec extends Specification {
                 .body("Lore ipsum body")
                 .build()
         when:
-        def message = defaultMessageComposer.compose(email, null)
+        Message message = defaultMessageComposer.compose(email, null)
 
         then:
         [from] == message.from.toList().collect {it.address }
@@ -127,7 +127,7 @@ class DefaultMessageComposerSpec extends Specification {
                 .body("Lore ipsum body")
                 .build()
         when:
-        def message = defaultMessageComposer.compose(email, null)
+        Message message = defaultMessageComposer.compose(email, null)
 
         then:
         [from] == message.from.toList().collect {it.address }

--- a/email-javamail-composer/src/test/groovy/io/micronaut/email/javamail/composer/DefaultMessageComposerSpec.groovy
+++ b/email-javamail-composer/src/test/groovy/io/micronaut/email/javamail/composer/DefaultMessageComposerSpec.groovy
@@ -112,11 +112,11 @@ class DefaultMessageComposerSpec extends Specification {
 
     void "from, to, multiple reply to and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def replyTo1 = "sender.reply.to.one@example.com"
-        def replyTo2 = "sender.reply.to.two@example.com"
-        def subject = "Apple Music"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String replyTo1 = "sender.reply.to.one@example.com"
+        String replyTo2 = "sender.reply.to.two@example.com"
+        String subject = "Apple Music"
 
         Email email = Email.builder()
                 .from(from)

--- a/email-javamail-composer/src/test/groovy/io/micronaut/email/javamail/composer/DefaultMessageComposerSpec.groovy
+++ b/email-javamail-composer/src/test/groovy/io/micronaut/email/javamail/composer/DefaultMessageComposerSpec.groovy
@@ -109,4 +109,31 @@ class DefaultMessageComposerSpec extends Specification {
         subject == message.getSubject()
         !message.getRecipients(Message.RecipientType.CC)
     }
+
+    void "from, to, multiple reply to and subject are put to the mime message"() {
+        given:
+        def from = "sender@example.com"
+        def to = "receiver@example.com"
+        def replyTo1 = "sender.reply.to.one@example.com"
+        def replyTo2 = "sender.reply.to.two@example.com"
+        def subject = "Apple Music"
+
+        Email email = Email.builder()
+                .from(from)
+                .to(to)
+                .replyTo(replyTo1)
+                .replyTo(replyTo2)
+                .subject(subject)
+                .body("Lore ipsum body")
+                .build()
+        when:
+        def message = defaultMessageComposer.compose(email, null)
+
+        then:
+        [from] == message.from.toList().collect {it.address }
+        [to] == message.getRecipients(Message.RecipientType.TO).toList().collect{it.address}
+        [replyTo1, replyTo2] == message.replyTo.toList().collect {it.address }
+        subject == message.getSubject()
+        !message.getRecipients(Message.RecipientType.CC)
+    }
 }

--- a/email-mailjet/build.gradle.kts
+++ b/email-mailjet/build.gradle.kts
@@ -10,5 +10,5 @@ dependencies {
     implementation(mnValidation.micronaut.validation)
     testImplementation(projects.testSuiteUtils)
     testImplementation(mn.micronaut.http)
-    testImplementation(mn.jackson.databind)
+    testImplementation(mnSerde.micronaut.serde.jackson)
 }

--- a/email-mailjet/build.gradle.kts
+++ b/email-mailjet/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
     implementation(mnValidation.micronaut.validation)
     testImplementation(projects.testSuiteUtils)
     testImplementation(mn.micronaut.http)
+    testImplementation(mn.jackson.databind)
 }

--- a/email-mailjet/src/main/java/io/micronaut/email/mailjet/MailjetEmailComposer.java
+++ b/email-mailjet/src/main/java/io/micronaut/email/mailjet/MailjetEmailComposer.java
@@ -29,6 +29,8 @@ import io.micronaut.email.EmailException;
 import jakarta.inject.Singleton;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -42,11 +44,22 @@ import java.util.Optional;
  */
 @Singleton
 public class MailjetEmailComposer implements EmailComposer<MailjetRequest> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MailjetEmailComposer.class);
+
     @Override
     @NonNull
     public MailjetRequest compose(@NonNull @NotNull @Valid Email email) throws EmailException {
         JSONObject message = new JSONObject();
         message.put(Emailv31.Message.FROM, createJsonObject(email.getFrom()));
+        if (CollectionUtils.isNotEmpty(email.getReplyToCollection())) {
+            if (email.getReplyToCollection().size() > 1) {
+                if (LOG.isWarnEnabled()) {
+                    LOG.warn("Mailjet does not support multiple 'replyTo' addresses (Email has {} replyTo addresses)", email.getReplyToCollection().size());
+                }
+            }
+            message.put(Emailv31.Message.REPLYTO, createJsonObject(CollectionUtils.last(email.getReplyToCollection())));
+        }
         to(email).ifPresent(jsonArray -> message.put(Emailv31.Message.TO, jsonArray));
         message.put(Emailv31.Message.SUBJECT, email.getSubject());
         Body body = email.getBody();

--- a/email-mailjet/src/main/java/io/micronaut/email/mailjet/MailjetEmailComposer.java
+++ b/email-mailjet/src/main/java/io/micronaut/email/mailjet/MailjetEmailComposer.java
@@ -53,10 +53,8 @@ public class MailjetEmailComposer implements EmailComposer<MailjetRequest> {
         JSONObject message = new JSONObject();
         message.put(Emailv31.Message.FROM, createJsonObject(email.getFrom()));
         if (CollectionUtils.isNotEmpty(email.getReplyToCollection())) {
-            if (email.getReplyToCollection().size() > 1) {
-                if (LOG.isWarnEnabled()) {
-                    LOG.warn("Mailjet does not support multiple 'replyTo' addresses (Email has {} replyTo addresses)", email.getReplyToCollection().size());
-                }
+            if (email.getReplyToCollection().size() > 1 && LOG.isWarnEnabled()) {
+                LOG.warn("Mailjet does not support multiple 'replyTo' addresses (Email has {} replyTo addresses)", email.getReplyToCollection().size());
             }
             message.put(Emailv31.Message.REPLYTO, createJsonObject(CollectionUtils.last(email.getReplyToCollection())));
         }

--- a/email-mailjet/src/test/groovy/io/micronaut/email/mailjet/MailjetEmailComposerSpec.groovy
+++ b/email-mailjet/src/test/groovy/io/micronaut/email/mailjet/MailjetEmailComposerSpec.groovy
@@ -1,0 +1,44 @@
+package io.micronaut.email.mailjet
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.mailjet.client.MailjetRequest
+import io.micronaut.email.Email
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class MailjetEmailComposerSpec extends Specification {
+
+    @Inject
+    MailjetEmailComposer mailjetEmailComposer
+
+    void "from, to, only the last reply to and subject are put to the request"() {
+        given:
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String replyTo1 = "sender.reply.to.one@example.com"
+        String replyTo2 = "sender.reply.to.two@example.com"
+        String subject = "Apple Music"
+        String body = "Lore ipsum body"
+
+        Email email = Email.builder()
+                .from(from)
+                .to(to)
+                .replyTo(replyTo1)
+                .replyTo(replyTo2)
+                .subject(subject)
+                .body(body)
+                .build()
+        when:
+        MailjetRequest request = mailjetEmailComposer.compose(email)
+        Map map = new JsonMapper().readValue(request.body, Map)
+
+        then:
+        map["Messages"][0]["ReplyTo"]["Email"] == replyTo2
+        map["Messages"][0]["TextPart"] == body
+        map["Messages"][0]["From"]["Email"] == from
+        map["Messages"][0]["To"][0]["Email"] == to
+        map["Messages"][0]["Subject"] == subject
+    }
+}

--- a/email-mailjet/src/test/groovy/io/micronaut/email/mailjet/MailjetEmailComposerSpec.groovy
+++ b/email-mailjet/src/test/groovy/io/micronaut/email/mailjet/MailjetEmailComposerSpec.groovy
@@ -1,8 +1,8 @@
 package io.micronaut.email.mailjet
 
-import com.fasterxml.jackson.databind.json.JsonMapper
 import com.mailjet.client.MailjetRequest
 import io.micronaut.email.Email
+import io.micronaut.json.JsonMapper
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
@@ -12,6 +12,9 @@ class MailjetEmailComposerSpec extends Specification {
 
     @Inject
     MailjetEmailComposer mailjetEmailComposer
+
+    @Inject
+    JsonMapper jsonMapper
 
     void "from, to, only the last reply to and subject are put to the request"() {
         given:
@@ -32,7 +35,7 @@ class MailjetEmailComposerSpec extends Specification {
                 .build()
         when:
         MailjetRequest request = mailjetEmailComposer.compose(email)
-        Map map = new JsonMapper().readValue(request.body, Map)
+        Map map = jsonMapper.readValue(request.body, Map)
 
         then:
         map["Messages"][0]["ReplyTo"]["Email"] == replyTo2

--- a/email-postmark/src/main/java/io/micronaut/email/postmark/PostmarkEmailComposer.java
+++ b/email-postmark/src/main/java/io/micronaut/email/postmark/PostmarkEmailComposer.java
@@ -66,10 +66,8 @@ public class PostmarkEmailComposer implements EmailComposer<Message> {
             message.setTo(email.getTo().stream().map(Contact::getEmail).collect(Collectors.toList()));
         }
         if (CollectionUtils.isNotEmpty(email.getReplyToCollection())) {
-            if (email.getReplyToCollection().size() > 1) {
-                if (LOG.isWarnEnabled()) {
-                    LOG.warn("Postmark does not support multiple 'replyTo' addresses (Email has {} replyTo addresses)", email.getReplyToCollection().size());
-                }
+            if (email.getReplyToCollection().size() > 1 && LOG.isWarnEnabled()) {
+                LOG.warn("Postmark does not support multiple 'replyTo' addresses (Email has {} replyTo addresses)", email.getReplyToCollection().size());
             }
             message.setReplyTo(CollectionUtils.last(email.getReplyToCollection()).getEmail());
         }

--- a/email-postmark/src/test/groovy/io/micronaut/email/postmark/PostmarkEmailComposerSpec.groovy
+++ b/email-postmark/src/test/groovy/io/micronaut/email/postmark/PostmarkEmailComposerSpec.groovy
@@ -1,0 +1,49 @@
+package io.micronaut.email.postmark
+
+import com.postmarkapp.postmark.client.data.model.message.Message
+import io.micronaut.email.Email
+import io.micronaut.email.TrackLinks
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class PostmarkEmailComposerSpec extends Specification {
+
+    @Inject
+    PostmarkEmailComposer postmarkEmailComposer
+
+    @MockBean
+    PostmarkConfiguration postmarkConfiguration = Stub() {
+        getTrackLinks() >> TrackLinks.DO_NOT_TRACK
+    }
+
+    void "from, to, only the last reply to and subject are put to the message"() {
+        given:
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String replyTo1 = "sender.reply.to.one@example.com"
+        String replyTo2 = "sender.reply.to.two@example.com"
+        String subject = "Apple Music"
+        String body = "Lore ipsum body"
+
+        Email email = Email.builder()
+                .from(from)
+                .to(to)
+                .replyTo(replyTo1)
+                .replyTo(replyTo2)
+                .subject(subject)
+                .body(body)
+                .build()
+        when:
+        Message message = postmarkEmailComposer.compose(email)
+
+        then:
+        message.from == from
+        message.subject == subject
+        message.to == "\"$to\""
+        message.textBody == body
+        message.replyTo == replyTo2
+    }
+}

--- a/email-sendgrid/build.gradle.kts
+++ b/email-sendgrid/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
     implementation(mnValidation.micronaut.validation)
     testImplementation(mn.micronaut.http)
     testImplementation(projects.testSuiteUtils)
+    testImplementation(mnSerde.micronaut.serde.jackson)
 }

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailComposer.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailComposer.java
@@ -82,10 +82,8 @@ public class SendgridEmailComposer implements EmailComposer<Request> {
     private Optional<com.sendgrid.helpers.mail.objects.Email> createReplyTo(@NonNull Email email) {
         if (CollectionUtils.isEmpty(email.getReplyToCollection())) {
             return Optional.empty();
-        } else if (email.getReplyToCollection().size() > 1) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("Sendgrid does not support multiple 'replyTo' addresses (Email has {} replyTo addresses)", email.getReplyToCollection().size());
-            }
+        } else if (email.getReplyToCollection().size() > 1 && LOG.isWarnEnabled()) {
+            LOG.warn("Sendgrid does not support multiple 'replyTo' addresses (Email has {} replyTo addresses)", email.getReplyToCollection().size());
         }
         final Contact contact = CollectionUtils.last(email.getReplyToCollection());
         com.sendgrid.helpers.mail.objects.Email replyTo = new com.sendgrid.helpers.mail.objects.Email();

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailComposer.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailComposer.java
@@ -84,7 +84,7 @@ public class SendgridEmailComposer implements EmailComposer<Request> {
             return Optional.empty();
         } else if (email.getReplyToCollection().size() > 1) {
             if (LOG.isWarnEnabled()) {
-                LOG.warn("Sendgrid does not support multiple 'replyTo' addresses (Email has {})", email.getReplyToCollection().size());
+                LOG.warn("Sendgrid does not support multiple 'replyTo' addresses (Email has {} replyTo addresses)", email.getReplyToCollection().size());
             }
         }
         final Contact contact = CollectionUtils.last(email.getReplyToCollection());

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailComposer.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailComposer.java
@@ -22,6 +22,7 @@ import com.sendgrid.helpers.mail.objects.Attachments;
 import com.sendgrid.helpers.mail.objects.Content;
 import com.sendgrid.helpers.mail.objects.Personalization;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.email.Attachment;
 import io.micronaut.email.Body;
 import io.micronaut.email.BodyType;
@@ -36,6 +37,8 @@ import jakarta.validation.constraints.NotNull;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Composes {@link Request} for {@link io.micronaut.email.Email}.
@@ -45,6 +48,7 @@ import java.util.Optional;
 @Singleton
 public class SendgridEmailComposer implements EmailComposer<Request> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(SendgridEmailComposer.class);
     private static final String CONTENT_TYPE_TEXT_HTML = "text/html";
     private static final String CONTENT_TYPE_TEXT_PLAIN = "text/plain";
 
@@ -76,13 +80,18 @@ public class SendgridEmailComposer implements EmailComposer<Request> {
 
     @NonNull
     private Optional<com.sendgrid.helpers.mail.objects.Email> createReplyTo(@NonNull Email email) {
-        if (email.getReplyTo() == null) {
+        if (CollectionUtils.isEmpty(email.getReplyToCollection())) {
             return Optional.empty();
+        } else if (email.getReplyToCollection().size() > 1) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Sendgrid does not support multiple 'replyTo' addresses (Email has {})", email.getReplyToCollection().size());
+            }
         }
+        final Contact contact = CollectionUtils.last(email.getReplyToCollection());
         com.sendgrid.helpers.mail.objects.Email replyTo = new com.sendgrid.helpers.mail.objects.Email();
-        replyTo.setEmail(email.getReplyTo().getEmail());
-        if (email.getReplyTo().getName() != null) {
-            replyTo.setName(email.getReplyTo().getName());
+        replyTo.setEmail(contact.getEmail());
+        if (contact.getName() != null) {
+            replyTo.setName(contact.getName());
         }
         return Optional.of(replyTo);
     }

--- a/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendgridEmailComposerSpec.groovy
+++ b/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendgridEmailComposerSpec.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.email.sendgrid
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.json.JsonMapper
 import com.sendgrid.Request
 import io.micronaut.email.Email
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
@@ -32,7 +32,7 @@ class SendgridEmailComposerSpec extends Specification {
                 .build()
         when:
         Request request = sendgridEmailComposer.compose(email)
-        Map map = new ObjectMapper().readValue(request.body, Map)
+        Map map = new JsonMapper().readValue(request.body, Map)
 
         then:
         map["from"]["email"] == from

--- a/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendgridEmailComposerSpec.groovy
+++ b/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendgridEmailComposerSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.email.sendgrid
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.sendgrid.Request
 import io.micronaut.email.Email
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -30,8 +31,8 @@ class SendgridEmailComposerSpec extends Specification {
                 .body(body)
                 .build()
         when:
-        def request = sendgridEmailComposer.compose(email)
-        def map = new ObjectMapper().readValue(request.body, Map)
+        Request request = sendgridEmailComposer.compose(email)
+        Map map = new ObjectMapper().readValue(request.body, Map)
 
         then:
         map["from"]["email"] == from

--- a/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendgridEmailComposerSpec.groovy
+++ b/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendgridEmailComposerSpec.groovy
@@ -1,7 +1,7 @@
 package io.micronaut.email.sendgrid
 
-import com.fasterxml.jackson.databind.json.JsonMapper
 import com.sendgrid.Request
+import io.micronaut.json.JsonMapper
 import io.micronaut.email.Email
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -12,6 +12,9 @@ class SendgridEmailComposerSpec extends Specification {
 
     @Inject
     SendgridEmailComposer sendgridEmailComposer
+
+    @Inject
+    JsonMapper jsonMapper
 
     void "from, to, only the last reply to and subject are put to the mime message"() {
         given:
@@ -32,7 +35,7 @@ class SendgridEmailComposerSpec extends Specification {
                 .build()
         when:
         Request request = sendgridEmailComposer.compose(email)
-        Map map = new JsonMapper().readValue(request.body, Map)
+        Map map = jsonMapper.readValue(request.body, Map)
 
         then:
         map["from"]["email"] == from

--- a/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendgridEmailComposerSpec.groovy
+++ b/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendgridEmailComposerSpec.groovy
@@ -14,12 +14,12 @@ class SendgridEmailComposerSpec extends Specification {
 
     void "from, to, only the last reply to and subject are put to the mime message"() {
         given:
-        def from = "sender@example.com"
-        def to = "receiver@example.com"
-        def replyTo1 = "sender.reply.to.one@example.com"
-        def replyTo2 = "sender.reply.to.two@example.com"
-        def subject = "Apple Music"
-        def body = "Lore ipsum body"
+        String from = "sender@example.com"
+        String to = "receiver@example.com"
+        String replyTo1 = "sender.reply.to.one@example.com"
+        String replyTo2 = "sender.reply.to.two@example.com"
+        String subject = "Apple Music"
+        String body = "Lore ipsum body"
 
         Email email = Email.builder()
                 .from(from)

--- a/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendgridEmailComposerSpec.groovy
+++ b/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendgridEmailComposerSpec.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.email.sendgrid
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micronaut.email.Email
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class SendgridEmailComposerSpec extends Specification {
+
+    @Inject
+    SendgridEmailComposer sendgridEmailComposer
+
+    void "from, to, only the last reply to and subject are put to the mime message"() {
+        given:
+        def from = "sender@example.com"
+        def to = "receiver@example.com"
+        def replyTo1 = "sender.reply.to.one@example.com"
+        def replyTo2 = "sender.reply.to.two@example.com"
+        def subject = "Apple Music"
+        def body = "Lore ipsum body"
+
+        Email email = Email.builder()
+                .from(from)
+                .to(to)
+                .replyTo(replyTo1)
+                .replyTo(replyTo2)
+                .subject(subject)
+                .body(body)
+                .build()
+        when:
+        def request = sendgridEmailComposer.compose(email)
+        def map = new ObjectMapper().readValue(request.body, Map)
+
+        then:
+        map["from"]["email"] == from
+        map["subject"] == subject
+        map["personalizations"][0]["to"][0]["email"] == to
+        map["personalizations"][0]["subject"] == subject
+        map["content"][0]["type"] == "text/plain"
+        map["content"][0]["value"] == body
+        map["reply_to"]["email"] == replyTo2
+    }
+}

--- a/email/src/main/java/io/micronaut/email/Email.java
+++ b/email/src/main/java/io/micronaut/email/Email.java
@@ -18,6 +18,7 @@ package io.micronaut.email;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.email.validation.AnyRecipient;
 import io.micronaut.email.validation.Recipients;
 
@@ -45,8 +46,7 @@ public final class Email implements Recipients {
     private final Contact from;
 
     @Nullable
-    @Valid
-    private final Contact replyTo;
+    private final Collection<@Valid Contact> replyTo;
 
     @Nullable
     private final Collection<@Valid Contact> to;
@@ -80,7 +80,7 @@ public final class Email implements Recipients {
      * @param body Email Body
      */
     private Email(@NonNull Contact from,
-                 @Nullable Contact replyTo,
+                 @Nullable List<Contact> replyTo,
                  @Nullable List<Contact> to,
                  @Nullable List<Contact> cc,
                  @Nullable List<Contact> bcc,
@@ -104,6 +104,11 @@ public final class Email implements Recipients {
 
     @Nullable
     public Contact getReplyTo() {
+        return CollectionUtils.isEmpty(replyTo) ? null : CollectionUtils.last(replyTo);
+    }
+
+    @Nullable
+    public Collection<@Valid Contact> getReplyToCollection() {
         return replyTo;
     }
 
@@ -163,7 +168,7 @@ public final class Email implements Recipients {
         private String subject;
 
         @Nullable
-        private Contact replyTo;
+        private List<Contact> replyTo;
 
         @Nullable
         private List<Contact> cc;
@@ -206,7 +211,7 @@ public final class Email implements Recipients {
          */
         @NonNull
         public Email.Builder replyTo(@NonNull String replyTo) {
-            this.replyTo = new Contact(replyTo);
+            addReplyTo(new Contact(replyTo));
             return this;
         }
 
@@ -217,8 +222,15 @@ public final class Email implements Recipients {
          */
         @NonNull
         public Email.Builder replyTo(@NonNull Contact replyTo) {
-            this.replyTo = replyTo;
+            addReplyTo(replyTo);
             return this;
+        }
+
+        private void addReplyTo(@NonNull Contact replyTo) {
+            if (this.replyTo == null) {
+                this.replyTo = new ArrayList<>();
+            }
+            this.replyTo.add(replyTo);
         }
 
         /**
@@ -455,6 +467,15 @@ public final class Email implements Recipients {
          */
         @NonNull
         public Optional<Contact> getReplyTo() {
+            return CollectionUtils.isEmpty(replyTo) ? Optional.empty() : Optional.of(CollectionUtils.last(replyTo));
+        }
+
+        /**
+         *
+         * @return Email Reply-to
+         */
+        @NonNull
+        public Optional<List<Contact>> getReplyToList() {
             return Optional.ofNullable(replyTo);
         }
 

--- a/email/src/main/java/io/micronaut/email/Email.java
+++ b/email/src/main/java/io/micronaut/email/Email.java
@@ -97,49 +97,96 @@ public final class Email implements Recipients {
         this.body = body;
     }
 
+    /**
+     * Returns this email "From" address.
+     *
+     * @return this email "From" address.
+     */
     @NonNull
     public Contact getFrom() {
         return from;
     }
 
+    /**
+     * Returns this email's "Reply-To" address.
+     *
+     * <p>Note: If this email has more than one, this method will return the last one added.
+     *
+     * @return this email's "Reply-To" address.
+     */
     @Nullable
     public Contact getReplyTo() {
         return CollectionUtils.isEmpty(replyTo) ? null : CollectionUtils.last(replyTo);
     }
 
+    /**
+     * Returns this email's "Reply-To" addresses.
+     *
+     * @return this email's "Reply-To" addresses.
+     */
     @Nullable
     public Collection<@Valid Contact> getReplyToCollection() {
         return replyTo;
     }
 
+    /**
+     * Returns this email's "To" addresses.
+     *
+     * @return this email's "To" addresses.
+     */
     @Override
     @Nullable
     public Collection<Contact> getTo() {
         return to;
     }
 
+    /**
+     * Returns this email's "CC" addresses.
+     *
+     * @return this email's "CC" addresses.
+     */
     @Override
     @Nullable
     public Collection<Contact> getCc() {
         return cc;
     }
 
+    /**
+     * Returns this email's "BCC" addresses.
+     *
+     * @return this email's "BCC" addresses.
+     */
     @Override
     @Nullable
     public Collection<Contact> getBcc() {
         return bcc;
     }
 
+    /**
+     * Returns this email's subject.
+     *
+     * @return this email's subject.
+     */
     @NonNull
     public String getSubject() {
         return subject;
     }
 
+    /**
+     * Returns this email's attachments.
+     *
+     * @return this email's attachments.
+     */
     @Nullable
     public List<Attachment> getAttachments() {
         return attachments;
     }
 
+    /**
+     * Returns this email's body.
+     *
+     * @return this email's body.
+     */
     @Nullable
     public Body getBody() {
         return body;

--- a/email/src/test/groovy/io/micronaut/email/EmailSpec.groovy
+++ b/email/src/test/groovy/io/micronaut/email/EmailSpec.groovy
@@ -208,4 +208,51 @@ class EmailSpec extends Specification {
         then:
         validator.validate(email)
     }
+
+    void "if provided, replyTo must be a valid email address"() {
+        given:
+        Email email = Email.builder()
+                .from("tcook@apple.com")
+                .to("ecue@apple.com")
+                .subject("Apple Music")
+                .body("Stream music to your device")
+                .replyTo("poppenheimer")
+                .build()
+        expect:
+        validator.validate(email)
+    }
+
+    void "replyToCollection can contain multiple addresses"() {
+        given:
+        Email email = Email.builder()
+                .from("tcook@apple.com")
+                .to("ecue@apple.com")
+                .subject("Apple Music")
+                .body("Stream music to your device")
+                .replyTo("poppenheimer@apple.com")
+                .replyTo("mmorehouse@apple.com")
+                .build()
+
+        expect:
+        !validator.validate(email)
+        email.replyToCollection.size() == 2
+        email.replyToCollection[0].email == "poppenheimer@apple.com"
+        email.replyToCollection[1].email == "mmorehouse@apple.com"
+    }
+
+    void "replyTo returns the last address for backward compatibility"() {
+        given:
+        Email email = Email.builder()
+                .from("tcook@apple.com")
+                .to("ecue@apple.com")
+                .subject("Apple Music")
+                .body("Stream music to your device")
+                .replyTo("poppenheimer@apple.com")
+                .replyTo("mmorehouse@apple.com")
+                .build()
+
+        expect:
+        !validator.validate(email)
+        email.replyTo.email == 'mmorehouse@apple.com'
+    }
 }


### PR DESCRIPTION
Added support for multiple `replyTo` per `Email` in a backward-compatible way.

Sendgrid does not support multiple 'replyTo' addresses, so we will log a warning.

Closes #217 