### PR TITLE
Introduce SendGridFactory

### DIFF
--- a/email-sendgrid/build.gradle.kts
+++ b/email-sendgrid/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     api(libs.managed.sendgrid.java)
     api(projects.micronautEmail)
     implementation(mnReactor.micronaut.reactor)
+    testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mn.micronaut.http)
     testImplementation(projects.testSuiteUtils)
     testImplementation(mnSerde.micronaut.serde.jackson)

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridFactory.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridFactory.java
@@ -19,6 +19,7 @@ package io.micronaut.email.sendgrid;
 import com.sendgrid.SendGrid;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import jakarta.inject.Singleton;
 
@@ -28,6 +29,7 @@ import jakarta.inject.Singleton;
  * @author Daniel Muhra
  */
 @Factory
+@Internal
 @Requires(beans = SendGridConfiguration.class)
 class SendGridFactory {
 

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridFactory.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.email.sendgrid;
+
+import com.sendgrid.SendGrid;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import jakarta.inject.Singleton;
+
+/**
+ * Builds a {@link SendGrid} from configuration set at {@link SendGridConfiguration}.
+ *
+ * @author Daniel Muhra
+ */
+@Factory
+@Requires(beans = SendGridConfiguration.class)
+public class SendGridFactory {
+
+    /**
+     * @param configuration SendGrid Configuration
+     * @return a sendgrid instance.
+     */
+    @Singleton
+    @NonNull
+    public SendGrid buildSendGrid(SendGridConfiguration configuration) {
+        return new SendGrid(configuration.getApiKey());
+    }
+}

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridFactory.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridFactory.java
@@ -29,7 +29,7 @@ import jakarta.inject.Singleton;
  */
 @Factory
 @Requires(beans = SendGridConfiguration.class)
-public class SendGridFactory {
+class SendGridFactory {
 
     /**
      * @param configuration SendGrid Configuration
@@ -37,7 +37,7 @@ public class SendGridFactory {
      */
     @Singleton
     @NonNull
-    public SendGrid buildSendGrid(SendGridConfiguration configuration) {
+    SendGrid buildSendGrid(@NonNull SendGridConfiguration configuration) {
         return new SendGrid(configuration.getApiKey());
     }
 }

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridFactory.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridFactory.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.micronaut.email.sendgrid;
 
 import com.sendgrid.SendGrid;

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailSender.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailSender.java
@@ -39,11 +39,11 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
- * <a href="https://sendgrid.com">SendGrid</a> implementation of {@link io.micronaut.email.TransactionalEmailSender} and {@link io.micronaut.email.AsyncTransactionalEmailSender} .
+ * <a href="https://sendgrid.com">SendGrid</a> implemenstation of {@link io.micronaut.email.TransactionalEmailSender} and {@link io.micronaut.email.AsyncTransactionalEmailSender} .
  * @author Sergio del Amo
  * @since 1.0.0
  */
-@Requires(beans = { SendGridConfiguration.class, SendgridEmailComposer.class })
+@Requires(beans = { SendGrid.class, SendgridEmailComposer.class })
 @Named(SendgridEmailSender.NAME)
 @Singleton
 public class SendgridEmailSender implements TransactionalEmailSender<Request, Response>,
@@ -59,12 +59,12 @@ public class SendgridEmailSender implements TransactionalEmailSender<Request, Re
     private final SendgridEmailComposer sendgridEmailComposer;
 
     /**
-     * @param sendGridConfiguration SendGrid Configuration
+     * @param sendgrid SendGrid instance
      * @param sendgridEmailComposer SendGrid Email composer
      */
-    public SendgridEmailSender(SendGridConfiguration sendGridConfiguration,
+    public SendgridEmailSender(SendGrid sendgrid,
                                SendgridEmailComposer sendgridEmailComposer) {
-        sendGrid = new SendGrid(sendGridConfiguration.getApiKey());
+        this.sendGrid = sendgrid;
         this.sendgridEmailComposer = sendgridEmailComposer;
     }
 

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailSender.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailSender.java
@@ -25,6 +25,7 @@ import io.micronaut.email.AsyncTransactionalEmailSender;
 import io.micronaut.email.Email;
 import io.micronaut.email.EmailException;
 import io.micronaut.email.TransactionalEmailSender;
+import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
@@ -62,10 +63,21 @@ public class SendgridEmailSender implements TransactionalEmailSender<Request, Re
      * @param sendgrid SendGrid instance
      * @param sendgridEmailComposer SendGrid Email composer
      */
+    @Inject
     public SendgridEmailSender(SendGrid sendgrid,
                                SendgridEmailComposer sendgridEmailComposer) {
         this.sendGrid = sendgrid;
         this.sendgridEmailComposer = sendgridEmailComposer;
+    }
+
+    /**
+     * @param sendGridConfiguration SendGrid Configuration
+     * @param sendgridEmailComposer SendGrid Email composer
+     */
+    @Deprecated(forRemoval = true, since = "2.10.1")
+    public SendgridEmailSender(SendGridConfiguration sendGridConfiguration,
+                               SendgridEmailComposer sendgridEmailComposer) {
+        this(new SendGrid(sendGridConfiguration.getApiKey()), sendgridEmailComposer);
     }
 
     @Override

--- a/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendGridSpec.groovy
+++ b/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendGridSpec.groovy
@@ -3,10 +3,17 @@ package io.micronaut.email.sendgrid
 import com.sendgrid.SendGrid
 import io.micronaut.context.BeanContext
 import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.event.BeanCreatedEvent
+import io.micronaut.context.event.BeanCreatedEventListener
+import io.micronaut.core.annotation.NonNull
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Singleton
 import spock.lang.Specification
 import jakarta.inject.Inject
 
+
+@Property(name = "spec.name", value = "SendGridSpec")
 @Property(name = "sendgrid.api-key", value = "xxx")
 @MicronautTest(startApplication = false)
 class SendGridSpec extends Specification {
@@ -17,5 +24,12 @@ class SendGridSpec extends Specification {
     void "if you set sendgrid.enabled to false you disable Sendgrid integration"() {
         expect:
         beanContext.containsBean(SendGrid)
+
+        when:
+        SendGrid sendGrid = beanContext.getBean(SendGrid)
+
+        then:
+        sendGrid
+        5000 == sendGrid.getRateLimitSleep()
     }
 }

--- a/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendGridSpec.groovy
+++ b/email-sendgrid/src/test/groovy/io/micronaut/email/sendgrid/SendGridSpec.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.email.sendgrid
+
+import com.sendgrid.SendGrid
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Specification
+import jakarta.inject.Inject
+
+@Property(name = "sendgrid.api-key", value = "xxx")
+@MicronautTest(startApplication = false)
+class SendGridSpec extends Specification {
+
+    @Inject
+    BeanContext beanContext
+
+    void "if you set sendgrid.enabled to false you disable Sendgrid integration"() {
+        expect:
+        beanContext.containsBean(SendGrid)
+    }
+}

--- a/email-sendgrid/src/test/java/io/micronaut/email/sendgrid/SendGridBeanCreatedEventListener.java
+++ b/email-sendgrid/src/test/java/io/micronaut/email/sendgrid/SendGridBeanCreatedEventListener.java
@@ -1,0 +1,22 @@
+package io.micronaut.email.sendgrid;
+
+import com.sendgrid.SendGrid;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.annotation.NonNull;
+import jakarta.inject.Singleton;
+
+@Requires(property = "spec.name", value = "SendGridSpec")
+//tag::clazz[]
+@Singleton
+class SendGridBeanCreatedEventListener implements BeanCreatedEventListener<SendGrid> {
+
+    @Override
+    public SendGrid onCreated(@NonNull BeanCreatedEvent<SendGrid> event) {
+        SendGrid sendGrid = event.getBean();
+        sendGrid.setRateLimitSleep(5000);
+        return sendGrid;
+    }
+}
+//end::clazz[]

--- a/src/main/docs/guide/integrations/sendgrid.adoc
+++ b/src/main/docs/guide/integrations/sendgrid.adoc
@@ -7,3 +7,10 @@ You need to supply your SendGrid's _API key and secret_ via configuration:
 include::{includedir}configurationProperties/io.micronaut.email.sendgrid.SendGridConfigurationProperties.adoc[]
 
 TIP: See the guide for https://guides.micronaut.io/latest/micronaut-email-sendgrid.html[Send Emails with SendGrid from the Micronaut Framework] to learn more.
+
+You can create a bean of type `BeanCreatedEventListener<SendGrid>` to further customize the `SendGrid` instance.
+
+[source,java]
+----
+include::email-sendgrid/src/test/java/io/micronaut/email/sendgrid/SendGridBeanCreatedEventListener.java[indent=0,tag=clazz]
+----


### PR DESCRIPTION
- SendgridEmailSender used to create a SendGrid instance directly
- This made it impossible to replace the SendGrid instance in order to make adjusments
- An example for this would be to configure the Apache http client used by Sendgrid.
- Now this can be done using Micronauts DI mechanics