### PR TITLE
bug: sendgrid  mail::addContent twice if html and text

### DIFF
--- a/email-sendgrid/build.gradle.kts
+++ b/email-sendgrid/build.gradle.kts
@@ -10,4 +10,7 @@ dependencies {
     testImplementation(mn.micronaut.http)
     testImplementation(projects.testSuiteUtils)
     testImplementation(mnSerde.micronaut.serde.jackson)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+    testRuntimeOnly(mnTest.junit.platform.launcher)
 }

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailComposer.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendgridEmailComposer.java
@@ -36,6 +36,9 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,25 +61,50 @@ public class SendgridEmailComposer implements EmailComposer<Request> {
         return createRequest(createMail(email));
     }
 
+    /**
+     *
+     * @param email Email
+     * @return SendGrid representation of Email
+     */
     @NonNull
-    private Mail createMail(@NonNull Email email) {
+    Mail createMail(@NonNull Email email) {
         Mail mail = new Mail();
         mail.setFrom(createForm(email));
         mail.setSubject(email.getSubject());
         createReplyTo(email).ifPresent(mail::setReplyTo);
         mail.addPersonalization(createPersonalization(email));
-        contentOfEmail(email).ifPresent(mail::addContent);
-
+        for (Content content : contentOfEmail(email)) {
+            mail.addContent(content);
+        }
         if (email.getAttachments() != null) {
             for (Attachment att : email.getAttachments()) {
                 mail.addAttachments(new Attachments.Builder(att.getFilename(), new ByteArrayInputStream(att.getContent()))
-                        .withType(att.getContentType())
-                        .withContentId(att.getId())
-                        .withDisposition(att.getDisposition())
-                        .build());
+                    .withType(att.getContentType())
+                    .withContentId(att.getId())
+                    .withDisposition(att.getDisposition())
+                    .build());
             }
         }
         return mail;
+    }
+
+    /**
+     *
+     * @param email Email
+     * @return List of contents created with the email body.
+     */
+    @NonNull
+    static List<Content> contentOfEmail(@NonNull Email email) {
+        Body body = email.getBody();
+        if (body == null) {
+            return Collections.emptyList();
+        }
+        List<Content> result = new ArrayList<>();
+        body.get(BodyType.TEXT)
+            .ifPresent(s -> result.add(new Content(CONTENT_TYPE_TEXT_PLAIN, s)));
+        body.get(BodyType.HTML)
+            .ifPresent(s -> result.add(new Content(CONTENT_TYPE_TEXT_HTML, s)));
+        return result;
     }
 
     @NonNull
@@ -153,19 +181,5 @@ public class SendgridEmailComposer implements EmailComposer<Request> {
         } catch (IOException e) {
             throw new EmailException(e);
         }
-    }
-
-    @NonNull
-    private Optional<Content> contentOfEmail(@NonNull Email email) {
-        Body body = email.getBody();
-        if (body == null) {
-            return Optional.empty();
-        }
-        Optional<String> str = body.get(BodyType.HTML);
-        if (str.isPresent()) {
-            return Optional.of(new Content(CONTENT_TYPE_TEXT_HTML, str.get()));
-        }
-        str = body.get(BodyType.TEXT);
-        return str.map(s -> new Content(CONTENT_TYPE_TEXT_PLAIN, s));
     }
 }

--- a/email-sendgrid/src/test/java/io/micronaut/email/sendgrid/SendgridEmailComposerTest.java
+++ b/email-sendgrid/src/test/java/io/micronaut/email/sendgrid/SendgridEmailComposerTest.java
@@ -1,0 +1,63 @@
+package io.micronaut.email.sendgrid;
+
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.email.Contact;
+import io.micronaut.email.Email;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = "sendgrid.api-key", value = "xxx")
+@MicronautTest(startApplication = false)
+class SendgridEmailComposerTest {
+    @Test
+    void createMail(SendgridEmailComposer composer) {
+        Email email = email();
+        Mail mail = composer.createMail(email);
+        assertEquals(2, mail.getContent().size());
+    }
+
+    @Test
+    void contentOfEmail() {
+        Email email = email();
+        List<Content> contents = assertDoesNotThrow(() -> SendgridEmailComposer.contentOfEmail(email));
+        assertEquals(2, contents.size());
+        assertEquals("text/plain", contents.get(0).getType(), "text/plain should be before html");
+        assertEquals("text/html", contents.get(1).getType());
+    }
+
+    private static Email email() {
+        String html = """
+        <html>
+        <body>
+            <h1>Check out this cute cat!</h1>
+            <p>Here's an inline image embedded in the email:</p>
+            <img src="cid:cat" alt="Cute Cat" style="max-width: 600px; height: auto;">
+            <p>Isn't it adorable?</p>
+        </body>
+        </html>
+    """;
+
+        String text = """
+        Check out this cute cat!
+
+        Here's an inline image embedded in the email.
+        (Note: Plain text clients won't display the image)
+
+        Isn't it adorable?
+    """;
+        return Email.builder()
+            .subject("Test")
+            .from("micronautemailtest@gmail.com")
+            .to(new Contact("marketing@micronaut.io"))
+            .body(html, text).build();
+    }
+}


### PR DESCRIPTION
if html and text we should invoke twice ot the method mail:addContent first with text then with html