### PR TITLE
docs: clarify email guide configuration

### DIFF
--- a/email-javamail/src/main/java/io/micronaut/email/javamail/sender/JavaMailConfigurationProperties.java
+++ b/email-javamail/src/main/java/io/micronaut/email/javamail/sender/JavaMailConfigurationProperties.java
@@ -49,9 +49,9 @@ public class JavaMailConfigurationProperties implements JavaMailConfiguration {
     }
 
     /**
-     * If Mailjet integration is enabled. Default value: `{@value #DEFAULT_ENABLED}`
+     * If Jakarta Mail integration is enabled. Default value: `{@value #DEFAULT_ENABLED}`
      *
-     * @param enabled True if security is enabled
+     * @param enabled True if Jakarta Mail integration is enabled
      */
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridConfiguration.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridConfiguration.java
@@ -29,7 +29,7 @@ public interface SendGridConfiguration extends Toggleable {
 
     /**
      *
-     * @return The API (Application Programming Interface) keys to authenticate access to SendGrid service.
+     * @return The API key to authenticate access to the SendGrid service.
      */
     @NonNull
     String getApiKey();

--- a/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridConfigurationProperties.java
+++ b/email-sendgrid/src/main/java/io/micronaut/email/sendgrid/SendGridConfigurationProperties.java
@@ -61,7 +61,7 @@ public class SendGridConfigurationProperties implements SendGridConfiguration {
 
     /**
      *
-     * @return The API (Application Programming Interface) keys to authenticate access to SendGrid service.
+     * @return The API key to authenticate access to the SendGrid service.
      */
     @Override
     @NonNull
@@ -71,7 +71,7 @@ public class SendGridConfigurationProperties implements SendGridConfiguration {
 
     /**
      *
-     * @param apiKey The API (Application Programming Interface) keys to authenticate access to SendGrid service.
+     * @param apiKey The API key to authenticate access to the SendGrid service.
      */
     public void setApiKey(@NonNull String apiKey) {
         this.apiKey = apiKey;

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,12 +1,12 @@
-This section documents breaking changes between Micronaut EMail versions:
+This section documents breaking changes between Micronaut Email versions:
 
-=== Micronaut Email 3.0.0
+== Micronaut Email 3.0.0
 
-- The constructor `io.micronaut.email.Attachment(String, String, byte[], String)` deprecated previously has been removed. Use `Attachment(String, String, byte[], String, String instead)`.
+- The previously deprecated constructor `io.micronaut.email.Attachment(String, String, byte[], String)` has been removed. Use `Attachment(String, String, byte[], String, String)` instead.
 
-- the class `io.micronaut.email.validation.AnyRecipientConstraintValidationFactory` deprecated previously has been removed. The `@Factory` annotation was intentionally removed. Thus, this class does nothing. `AnyRecipientValidator` is used instead.
+- The previously deprecated class `io.micronaut.email.validation.AnyRecipientConstraintValidationFactory` has been removed. The `@Factory` annotation was intentionally removed. Thus, this class does nothing. `AnyRecipientValidator` is used instead.
 
-=== Micronaut Email 2.0.0
+== Micronaut Email 2.0.0
 
 Micronaut Email 2.0.0 migrates to https://jakartaee.github.io/mail-api/[Jakarta Mail] package namespaces, from `javax.mail` to `jakarta.mail`. Moreover, it uses transitive dependency `jakarta.mail:jakarta.mail-api` instead of `com.sun.mail:javax.mail`. Jakarta Mail also separates API and Implementation. Previous implementation sources are now part of the https://eclipse-ee4j.github.io/angus-mail/[Eclipse Angus] project, the direct successor to JavaMail/JakartaMail. In addition to `jakarta-mail-api` an additional dependency on `org.eclipse.angus:angus-mail` is required. Note that for Eclipse Angus, module and package prefixes changed from `com.sun.mail` to `org.eclipse.angus.mail`.
 

--- a/src/main/docs/guide/integrations/javamail.adoc
+++ b/src/main/docs/guide/integrations/javamail.adoc
@@ -6,9 +6,14 @@ In addition, you will need to provide a runtime dependency on an implementation 
 
 dependency:angus-mail[groupId="org.eclipse.angus",scope="runtime"]
 
-You need to provide beans of type api:io.micronaut.email.javamail.sender.MailPropertiesProvider[] and api:io.micronaut.email.javamail.sender.SessionProvider[] to match your configuration.
+Micronaut Email can create beans of type api:io.micronaut.email.javamail.sender.MailPropertiesProvider[] and api:io.micronaut.email.javamail.sender.SessionProvider[] from `javamail.properties`.
+Configure the Jakarta Mail properties required by your transport, such as SMTP host, port, and TLS settings:
 
-### Authentication via configuration
+include::{includedir}configurationProperties/io.micronaut.email.javamail.sender.JavaMailConfigurationProperties.adoc[]
+
+Alternatively, provide your own api:io.micronaut.email.javamail.sender.MailPropertiesProvider[] or api:io.micronaut.email.javamail.sender.SessionProvider[] beans when you need complete control over the Jakarta Mail `Session`.
+
+== Authentication via configuration
 
 As an alternative to providing your own api:io.micronaut.email.javamail.sender.SessionProvider[] for authentication, you can configure password based authentication via configuration:
 
@@ -19,3 +24,5 @@ javamail:
     username: 'my.username'
     password: 'my.password'
 ----
+
+include::{includedir}configurationProperties/io.micronaut.email.javamail.sender.authentication.JavaMailAuthenticationConfigurationProperties.adoc[]

--- a/src/main/docs/guide/integrations/sendgrid.adoc
+++ b/src/main/docs/guide/integrations/sendgrid.adoc
@@ -2,7 +2,7 @@ To integrate with https://sendgrid.com[SendGrid], add the following dependency t
 
 dependency:micronaut-email-sendgrid[groupId="io.micronaut.email"]
 
-You need to supply your SendGrid's _API key and secret_ via configuration:
+You need to supply your SendGrid _API key_ via configuration:
 
 include::{includedir}configurationProperties/io.micronaut.email.sendgrid.SendGridConfigurationProperties.adoc[]
 


### PR DESCRIPTION
## Summary

- Clarifies that SendGrid configuration requires `sendgrid.api-key`, not an API secret.
- Documents the Jakarta Mail configuration path that creates `MailPropertiesProvider` and `SessionProvider` from `javamail.properties`, including generated authentication properties.
- Cleans the breaking-changes headings/copy so the guide no longer emits heading-level warnings.

## Validation

- `./gradlew -q publishGuide`
- `./gradlew :test-suite:test --tests 'io.micronaut.email.docs.*'`\n- `./gradlew :micronaut-email-sendgrid:test --tests 'io.micronaut.email.sendgrid.SendGridApiKeySpec' --tests 'io.micronaut.email.sendgrid.SendGridConfigurationSpec'`\n- `./gradlew :micronaut-email-javamail:test --tests 'io.micronaut.email.javamail.MailPropertiesProviderViaConfigurationSpec' --tests 'io.micronaut.email.javamail.AuthenticationPropertiesProviderViaConfigurationSpec' --tests 'io.micronaut.email.javamail.MailPropertiesProviderNotPresentByDefaultSpec'`\n- `./gradlew -p build/factcheck/mng-473 test`\n- `./gradlew -q docs`\n- `git diff --check`\n\nNotes: `publishGuide` still reports pre-existing missing Python snippet target warnings from the global snippet renderer. `docs` completes with existing Javadoc warnings outside this patch.\n\n---\n###### ✨ This message was AI-generated using gpt-5.5